### PR TITLE
Fixes amount of commits, issues and pull requests in repositories

### DIFF
--- a/src/app/entities/repository.ts
+++ b/src/app/entities/repository.ts
@@ -7,10 +7,10 @@ export class Repository {
     public license: string;
     public numOfContributors: number;
     public stars: number;
-    public commits: number;
-    public pullRequests: number;
+    public amountPreviousCommits: number;
+    public amountPreviousPullRequests: number;
     public forks: number;
-    public issues: number;
+    public amountPreviousIssues: number;
     public contributors: Member[];
     public githubURL: string;
 }

--- a/src/app/external-repositories/external-repositories.component.html
+++ b/src/app/external-repositories/external-repositories.component.html
@@ -73,15 +73,15 @@
                 </div>
                 <span>
                   <i class="fa fa-stop-circle mr-3 fa-3x"></i>
-                  <span class="text-primary">{{sumOf(repo.previousCommits.chartJSDataset)}}</span> Commits
+                  <span class="text-primary">{{repo.amountPreviousCommits}}</span> Commits
                 </span>
                 <span>
                   <i class="fa fa-question-circle-o mr-3 fa-3x"></i>
-                  <span class="text-primary">{{sumOf(repo.previousPullRequests.chartJSDataset)}}</span> Pull Requests
+                  <span class="text-primary">{{repo.amountPreviousPullRequests}}</span> Pull Requests
                 </span>
                 <span>
                   <i class="fa fa-exclamation-circle mr-3 fa-3x"></i>
-                  <span class="text-primary">{{sumOf(repo.previousIssues.chartJSDataset)}}</span> Issues
+                  <span class="text-primary">{{repo.amountPreviousIssues}}</span> Issues
                 </span>
               </div>
 

--- a/src/app/external-repositories/external-repositories.component.ts
+++ b/src/app/external-repositories/external-repositories.component.ts
@@ -45,14 +45,14 @@ export class ExternalRepositoriesComponent implements OnInit {
 
   sortByCommits() {
     this.extRepos.sort((a: Repository, b: Repository) => {
-      return +b.commits - +a.commits;
+      return +b.amountPreviousCommits - +a.amountPreviousCommits;
     });
     this.sortByTag = "Commits";
   }
 
   sortByIssues() {
     this.extRepos.sort((a: Repository, b: Repository) => {
-      return +b.issues - +a.issues;
+      return +b.amountPreviousIssues - +a.amountPreviousIssues;
     });
     this.sortByTag = "Issues";
   }
@@ -71,7 +71,7 @@ export class ExternalRepositoriesComponent implements OnInit {
 
   sortByPullRequests() {
     this.extRepos.sort((a: Repository, b: Repository) => {
-      return +b.pullRequests - +a.pullRequests;
+      return +b.amountPreviousPullRequests - +a.amountPreviousPullRequests;
     });
     this.sortByTag = "Pull Requests";
   }

--- a/src/app/repositories/repositories.component.html
+++ b/src/app/repositories/repositories.component.html
@@ -64,13 +64,13 @@
               <div class="team-info-container">
                 <span>
                   <i class="fa fa-stop-circle mr-3 fa-3x"></i>
-                  <span class="text-primary">{{repo.commits}}</span> Commits</span>
+                  <span class="text-primary">{{repo.amountPreviousCommits}}</span> Commits</span>
                 <span>
                   <i class="fa fa-question-circle-o mr-3 fa-3x"></i>
-                  <span class="text-primary">{{repo.pullRequests}}</span> Pull Requests</span>
+                  <span class="text-primary">{{repo.amountPreviousPullRequests}}</span> Pull Requests</span>
                 <span>
                   <i class="fa fa-exclamation-circle mr-3 fa-3x"></i>
-                  <span class="text-primary">{{repo.issues}}</span> Issues</span>
+                  <span class="text-primary">{{repo.amountPreviousIssues}}</span> Issues</span>
               </div>
             </div>
           </div>

--- a/src/app/repositories/repositories.component.ts
+++ b/src/app/repositories/repositories.component.ts
@@ -46,14 +46,14 @@ export class RepositoriesComponent implements OnInit {
 
   sortByCommits() {
     this.repositories.sort((a: Repository, b: Repository) => {
-      return +b.commits - +a.commits;
+      return +b.amountPreviousCommits - +a.amountPreviousCommits;
     });
     this.sortByTag = "Commits";
   }
 
   sortByIssues() {
     this.repositories.sort((a: Repository, b: Repository) => {
-      return +b.issues - +a.issues;
+      return +b.amountPreviousIssues - +a.amountPreviousIssues;
     });
     this.sortByTag = "Issues";
   }
@@ -72,7 +72,7 @@ export class RepositoriesComponent implements OnInit {
 
   sortByPullRequests() {
     this.repositories.sort((a: Repository, b: Repository) => {
-      return +b.pullRequests - +a.pullRequests;
+      return +b.amountPreviousPullRequests - +a.amountPreviousPullRequests;
     });
     this.sortByTag = "Pull Requests";
   }

--- a/src/app/team/team.component.ts
+++ b/src/app/team/team.component.ts
@@ -68,7 +68,7 @@ export class TeamComponent implements OnInit {
     });
 
     this.teamRepositories.sort((a: Repository, b: Repository) => {
-      return +b.commits - +a.commits;
+      return +b.amountPreviousCommits - +a.amountPreviousCommits;
     });
     this.sortByTag = "Commits";
   }
@@ -79,7 +79,7 @@ export class TeamComponent implements OnInit {
     });
 
     this.teamRepositories.sort((a: Repository, b: Repository) => {
-      return +b.issues - +a.issues;
+      return +b.amountPreviousIssues - +a.amountPreviousIssues;
     });
     this.sortByTag = "Issues";
   }
@@ -90,7 +90,7 @@ export class TeamComponent implements OnInit {
     });
 
     this.teamRepositories.sort((a: Repository, b: Repository) => {
-      return +b.pullRequests - +a.pullRequests;
+      return +b.amountPreviousPullRequests - +a.amountPreviousPullRequests;
     });
     this.sortByTag = "Pull Requests";
   }


### PR DESCRIPTION
In my opinion it makes sense to keep the calculation logic in the back-end and only do the display of the data in the front-end.
So I added the calculation in the back-end for the number of commits, issues and pull requests.
Needed [Pull Request](https://github.com/adessoAG/GitStalker-Spring/pull/54)  in the Back-End.

Fixes #19
Fixes #16

Another approach as a solution #21